### PR TITLE
#4: make sure we set correct self

### DIFF
--- a/foo.nix
+++ b/foo.nix
@@ -1,0 +1,3 @@
+{ nixpkgs-python, version }:
+
+nixpkgs-python.${version}


### PR DESCRIPTION
Fix #4 

It still fails with:

```
❯ nix shell '.#"3.11"'.interpreter
error: flake output attribute 'packages.x86_64-linux.3.11.interpreter' evaluates to the string '/nix/store/9gwacwbz0vrqjsbsrnq44hvyfw8jwmzh-python3-3.11.3/bin/python3.11' which is not a store path

❯ /nix/store/9gwacwbz0vrqjsbsrnq44hvyfw8jwmzh-python3-3.11.3/bin/python3.11
Python 3.11.3 (main, Apr  4 2023, 22:36:41) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 
```