### PR TITLE
Make it possible to use .withPackages and .pkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,8 +13,8 @@
     extra-trusted-public-keys = "nixpkgs-python.cachix.org-1:hxjI7pFxTyuTHn2NkvWCrAUcNZLNS3ZAvfYNuYifcEU=";
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }: 
-    let 
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    let
       systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
       forAllSystems = f: builtins.listToAttrs (map (name: { inherit name; value = f name; }) systems);
       lib = nixpkgs.lib;
@@ -90,7 +90,7 @@
                 url = "https://bugs.python.org/file48016/python-3.x-distutils-C++.patch";
                 sha256 = "1h18lnpx539h5lfxyk379dxwr8m2raigcjixkf133l4xy3f4bzi2";
               });
-            } 
+            }
             { condition = version: versionInBetween version "3.7.4" "3.7.3";
               override = replacePatch "python-3.x-distutils-C++.patch" ./patches/python-3.7.3-distutils-C++.patch;
             }
@@ -130,7 +130,7 @@
                 # no existing patch available
                 noldconfigPatch = null;
                 # otherwise it segfaults
-                stdenv = 
+                stdenv =
                   if pkgs.stdenv.isLinux
                   then pkgs.overrideCC pkgs.stdenv pkgs.gcc8
                   else pkgs.stdenv;
@@ -139,7 +139,7 @@
             # fill in the missing pc file
             { condition = version: versionInBetween version "3.5.2" "3.0" && pkgs.stdenv.isLinux;
               override = pkg: pkg.overrideAttrs (old: {
-                postInstall = '' 
+                postInstall = ''
                   ln -s "$out/lib/pkgconfig/python-${pkg.passthru.sourceVersion.major}.${pkg.passthru.sourceVersion.minor}.pc" "$out/lib/pkgconfig/python3.pc"
                 ''+ old.postInstall;
               });

--- a/self.nix
+++ b/self.nix
@@ -1,3 +1,0 @@
-{ nixpkgs-python, version }: 
-
-nixpkgs-python.${version}


### PR DESCRIPTION
I got hit by both #12 and the error noted in #14.

I added `builtins.trace` to various places and observed that...

>  error: function 'anonymous lambda' called with unexpected argument 'x11Support'

In my case, this was coming from [tkinter](https://github.com/NixOS/nixpkgs/blob/126f49a01de5b7e35a43fd43f891ecf6d3a51459/pkgs/top-level/python-packages.nix#L11621), and `python.override.__functionArgs` at that point was an attribute set of `["nixpkgs-python", "version"]`. My understanding is `callPackage ./self.nix { inherit version; }` returns an overrideable version of the function defined in `self.nix`, and that's being passed down as the python object. I changed it to use the bare `packages.${version}` instead, but I'm not sure if that breaks something else.

> error: builder for '/nix/store/jwc3cbbp74lc3krq8ilkhgd7izg8bdxd-Python-3.8.17.tar.xz.drv' failed with exit code 1;

i.e. `src` and `hash` not getting overriden - I traced it down to this call chain:

```nix
/nix/store/yag8q0cdid0wljdkkzzkfg61y8azsj1c-xs5pk051y9dahjl2n28rsppq8fajz125-source/pkgs/development/interpreters/python/hooks/default.nix
  pythonInterpreter = super.python.pythonForBuild.interpreter;

/nix/store/yag8q0cdid0wljdkkzzkfg61y8azsj1c-xs5pk051y9dahjl2n28rsppq8fajz125-source/pkgs/development/interpreters/python/passthrufun.nix
    pythonForBuild = pythonOnBuildForHost.override { inherit packageOverrides; self = pythonForBuild; };

/nix/store/yag8q0cdid0wljdkkzzkfg61y8azsj1c-xs5pk051y9dahjl2n28rsppq8fajz125-source/pkgs/development/interpreters/python/cpython/default.nix
    pythonOnBuildForHost = override pkgsBuildHost.${pythonAttr};
```

..and I forcefully replaced `pkgsBuildHost` with an attrset with `${pythonAttr}` set to nixpkgs-python's Python package, which worked, but I'm not sure if that's the right or the cleanest way.

Also needed to use `newScope` to make packages under `xorg` available in `callPackage` calls, e.g. `xorgproto`.

<details><summary>A slightly stripped down version of a `flake.nix` that I wanted to use `withPackage` with, which now works with this patch</summary>
<p>

```nix
{
  description = "Description for the project";

  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
    nixpkgs-python.url = "github:ento/nixpkgs-python/with-packages-fix";
    devenv.url = "github:cachix/devenv";
    nix2container.url = "github:nlewo/nix2container";
    nix2container.inputs.nixpkgs.follows = "nixpkgs";
    mk-shell-bin.url = "github:rrbutani/nix-mk-shell-bin";
  };

  nixConfig = {
    extra-trusted-public-keys = "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=";
    extra-substituters = "https://devenv.cachix.org";
  };

  outputs = inputs@{ flake-parts, ... }:
    flake-parts.lib.mkFlake { inherit inputs; } {
      imports = [
        inputs.devenv.flakeModule
      ];
      systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];

      perSystem = { config, self', inputs', pkgs, system, lib, ... }:
        let
          pythonVersions = [
            "3.8"
            "3.9"
            "3.10"
            "3.11"
          ];
          mkShell = v:
            let
              isDefaultPython = v == (lib.versions.majorMinor pkgs.python3.version);
              python =
                if isDefaultPython then
                  pkgs.python3
                else
                  inputs'.nixpkgs-python.packages.${v};
              pythonPackages = ps: with ps; [
                build
                pip-tools
                tox
                twine
              ];
              pythonWithPackages = (python.withPackages pythonPackages);
              shell = {
                name = v;
                packages = [
                  pkgs.pre-commit
                  python.pkgs.wrapPython
                ];
                languages.python.enable = true;
                languages.python.version = v;
                languages.python.package = lib.mkForce pythonWithPackages;
              };
            in
              [ { name = lib.replaceStrings ["."] [""] v; value = shell; } ]
              ++ (lib.optionals isDefaultPython [ { name = "default"; value = shell; }]);
        in {
        devenv.shells = lib.trivial.pipe pythonVersions [
          (map mkShell)
          lib.flatten
          lib.listToAttrs
        ];
      };
    };
}
```

```sh
nix develop .#310 --impure
```

</p>
</details> 