### PR TITLE
fix: use offical nixpkgs branch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "All Python versions packages in Nix.";
 
   inputs = {
-    nixpkgs.url = "github:domenkozar/nixpkgs/cpython-moduralize";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
 
     flake-compat.url = "github:edolstra/flake-compat";
     flake-compat.flake = false;


### PR DESCRIPTION
This PR is for this Issue: https://github.com/cachix/devenv/issues/891

The problem mentioned there is because of the hard coded inputs to an old nixpkgs fork. After i changed it to the offical repo (and stable version branch) it worked.

What i don't like is that hard coded url, maybe there is a better solution but i just started evaluating devenv today (and haven't used nix before)