### PR TITLE
Fix patching Lib/subprocess.py for 3.0 - 3.6 on NixOS 24.05

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -139,6 +139,14 @@
                   else pkgs.stdenv;
               });
             }
+            # compatibility with substitutions done by the nixpkgs derivation
+            { condition = version: versionInBetween version "3.7" "3.0";
+              override = pkg: pkg.overrideAttrs  (old: {
+                prePatch = ''
+                  substituteInPlace Lib/subprocess.py --replace '"/bin/sh"' "'/bin/sh'"
+                '' + old.prePatch;
+              });
+            }
             # fill in the missing pc file
             { condition = version: versionInBetween version "3.5.2" "3.0" && pkgs.stdenv.isLinux;
               override = pkg: pkg.overrideAttrs (old: {


### PR DESCRIPTION
This fixes a build failure with current stable nixpkgs.

The failure:
```
(...)
applying patch /nix/store/1wdbqiy7cmci9xj9p75py1r3nhpp69v2-8ea6353.patch
patching file configure
Hunk #1 succeeded at 3420 (offset -6 lines).
patching file configure.ac
Hunk #1 succeeded at 489 (offset -21 lines).
patching file Misc/NEWS.d/next/macOS/2020-06-24-13-51-57.bpo-41100.mcHdc5.rst
substituteStream() in derivation python3-3.4.10: ERROR: pattern \'/bin/sh\' doesn't match anything in file 'Lib/subprocess.py'
/nix/store/dd7nxjnni7nzm0846fq5xrm89ais5lwz-stdenv-linux/setup: line 131: pop_var_context: head of shell_variables not a function context
```

I've tested this change for a few Python versions:
```sh
nix build --override-input nixpkgs github:NixOS/nixpkgs/nixos-24.05 --cores 12 --accept-flake-config '.#"3.3"' '.#"3.4"' '.#"3.4.0"' '.#"3.5"' '.#"3.6"' '.#"3.7"' '.#"3.12"'
```