### PR TITLE
Use OpenSSL 1.0.x for old Python

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -32,10 +32,28 @@
         "type": "github"
       }
     },
+    "nixpkgs-1809": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1558254092,
+        "narHash": "sha256-5v6XuO9dOVpB3ZGNyDvLqOvCnzlyyvscTYbNiQouSZo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a7e559a5504572008567383c3dc8e142fa7a8633",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-18.09",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-1809": "nixpkgs-1809"
       }
     }
   },


### PR DESCRIPTION
This is more of an RFC than a Pull Request: only some versions work here. I'm not sure if this is the correct approach. I'll finish this if you think this is the way forward.

Different Python versions need different OpenSSL versions. This PR is an example of adding OpenSSL 1.0.x, required for 3.4. It builds, I can use pip, but I had to skip the certificate check for pypi.python.org. It's not great, but if an app is stuck on Python 3.4 then it's still better than nothing.

Is the approach of importing old openssl versions from different branches of nixpkgs sensible? Or would it make more sense to either copy the openssl package, or create a "nixpkgs-openssl" repo?

I believe this could solve https://github.com/cachix/nixpkgs-python/issues/23 - Python requires ssl to build pip.

Before:
```
rm -rf _venv/; nix build '.#"3.4"' && ./result/bin/python -mvenv _venv && ./_venv/bin/pip install --trusted-host pypi.python.org requests
bash: ./_venv/bin/pip: No such file or directory
```

After:
```
rm -rf _venv/; nix build '.#"3.4"' && ./result/bin/python -mvenv _venv && ./_venv/bin/pip install --trusted-host pypi.python.org requests
trace: nixpkgs-python
Collecting requests
  Using cached https://files.pythonhosted.org/packages/7d/e3/20f3d364d6c8e5d2353c72a67778eb189176f08e873c9900e10c0287b84b/requests-2.21.0-py2.py3-none-any.whl
Collecting chardet<3.1.0,>=3.0.2 (from requests)
  Using cached https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl
Collecting certifi>=2017.4.17 (from requests)
  Using cached https://files.pythonhosted.org/packages/37/45/946c02767aabb873146011e665728b680884cd8fe70dde973c640e45b775/certifi-2021.10.8-py2.py3-none-any.whl
Collecting urllib3<1.25,>=1.21.1 (from requests)
  Using cached https://files.pythonhosted.org/packages/01/11/525b02e4acc0c747de8b6ccdab376331597c569c42ea66ab0a1dbd36eca2/urllib3-1.24.3-py2.py3-none-any.whl
Collecting idna<2.9,>=2.5 (from requests)
  Using cached https://files.pythonhosted.org/packages/14/2c/cd551d81dbe15200be1cf41cd03869a46fe7226e7450af7a6545bfc474c9/idna-2.8-py2.py3-none-any.whl
Installing collected packages: chardet, certifi, urllib3, idna, requests
Successfully installed certifi-2021.10.8 chardet-3.0.4 idna-2.8 requests-2.21.0 urllib3-1.24.3
You are using pip version 9.0.1, however version 24.1.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```