### PR TITLE
Python 2.7 for NixOS 24.05

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,10 @@
             { condition = version: versionInBetween version "2.7.17" "2.7.6";
               override = replacePatch "python-2.7-distutils-C++.patch" ./patches/2.7.17-distutils-C++.patch;
             }
+            # this patch reverts an ActiveState change that was introduced in 2.7.18.8
+            { condition = version: versionInBetween version "2.7.18.8" "2.7";
+              override = pkg: filterOutPatch "20ea5b46aaf1e7bdf9d6905ba8bece2cc73b05b0.patch" pkg;
+            }
             # py3
             { condition = version: versionInBetween version "3.8.7" "3.8";
               override = overrideLDConfigPatch ./patches/3.8.6-no-ldconfig.patch;

--- a/update.py
+++ b/update.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 
 source = lambda version: f"https://www.python.org/ftp/python/{version}/Python-{version}.tgz"
+activestate_source = lambda version: f"https://github.com/ActiveState/cpython/archive/refs/tags/v{version}.tar.gz"
 
 # open versions.json and parse json
 def get_versions():
@@ -58,6 +59,30 @@ def get_all_releases(response, versions):
                 }
     return versions
 
+def get_activestate_releases(response, versions):
+    for entry in response.json():
+        version = entry["tag_name"].lstrip("v")
+        cycle = '.'.join(version.split('.')[:2])
+        release = versions['releases'].get(version, {})
+
+        if cycle != "2.7":
+            continue
+
+        versions['latest'][cycle] = max(version, versions['latest'].get(cycle, ''))
+
+        if release.get("hash"):
+            continue
+        else:
+            url = activestate_source(version)
+            print(f'Downloading {url}')
+            response = requests.get(url)
+            response.raise_for_status()
+            versions['releases'][version] = {
+                "hash": calculate_sha256(response.content),
+                "url": url
+            }
+    return versions
+
 def calculate_sha256(contents):
     return base64.b64encode(hashlib.sha256(contents).digest()).decode('utf-8')
 
@@ -68,5 +93,9 @@ if __name__ == "__main__":
     response = requests.get("https://endoflife.date/api/python.json")
 
     versions = get_all_releases(response, versions)
+
+    activestate_response = requests.get("https://api.github.com/repos/ActiveState/cpython/releases")
+    versions = get_activestate_releases(activestate_response, versions)
+
     with open("versions.json", "w") as f:
         json.dump(versions, f, indent=4)

--- a/versions.json
+++ b/versions.json
@@ -579,6 +579,18 @@
         "3.12.4": {
             "hash": "AbPBwIIZbzszFo00SpyF+we/4Ofs/nf+5EQ0INHOKtk=",
             "url": "https://www.python.org/ftp/python/3.12.4/Python-3.12.4.tgz"
+        },
+        "2.7.18.1": {
+            "hash": "Pw2VZwNLmgpf1cKKM5sqh2a15Kub1+7YMQ/4TUUDUO4=",
+            "url": "https://github.com/ActiveState/cpython/archive/refs/tags/v2.7.18.1.tar.gz"
+        },
+        "2.7.18.8": {
+            "hash": "I5zq0CGYTmY0/UO66GQVWqXwlOx/XovbZvQdSzJ3hB4=",
+            "url": "https://github.com/ActiveState/cpython/archive/refs/tags/v2.7.18.8.tar.gz"
+        },
+        "2.7.18.9": {
+            "hash": "Tl94mHYHLTDKhYxwaPVvPqhNC+V2QzV+F67jKSMA39U=",
+            "url": "https://github.com/ActiveState/cpython/archive/refs/tags/v2.7.18.9.tar.gz"
         }
     },
     "latest": {
@@ -592,6 +604,6 @@
         "3.5": "3.5.10",
         "3.4": "3.4.10",
         "3.3": "3.3.7",
-        "2.7": "2.7.18"
+        "2.7": "2.7.18.9"
     }
 }


### PR DESCRIPTION
This PR does 2 things:
1. it fixes building 2.7 (before 2.7.18.8) with NixOS 24.05
2. it adds ActiveState Python 2.7 versions

The change in "latest"."2.7" only really makes sense with current nixpkgs, and not with 23.11, because 2.7.18.9 on 23.11 doesn't seem to pick up OpenSSL.