### PR TITLE
Fix sourceVersion for 4 element versions (like 2.7.18.9)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,11 +34,12 @@
         }:
         let
           versionList = builtins.splitVersion version;
+          versionSuffixList = builtins.concatLists [[""] (lib.drop 3 versionList)];
           sourceVersion = {
             major = builtins.elemAt versionList 0;
             minor = builtins.elemAt versionList 1;
             patch = builtins.elemAt versionList 2;
-            suffix = "";
+            suffix = builtins.concatStringsSep "." versionSuffixList;
           };
           infix = if sourceVersion.major == "2" then "2.7/" else "";
           overrideLDConfigPatch = path: pkg: pkg.override {


### PR DESCRIPTION
It turns out my previous PR #49 was incomplete: it fixed building *something*, but it also broke building the `ssl` module for 2.7.18.8+.

This time I've added a test that checks if the ssl module is available. So far the test only runs for Python 2.7.18.*, other versions still have problems with building this module.