### PR TITLE
Fix ensurepip segfault for 3.6, add ensurepip test

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -133,6 +133,19 @@
                 })];
               });
             }
+            # Fix ensurepip for 3.6: https://bugs.python.org/issue45700
+            { condition = version: versionInBetween version "3.6.15" "3.6";
+              override = pkg: pkg.overrideAttrs (old: {
+                patches = old.patches ++ [(pkgs.fetchpatch {
+                  url = "https://github.com/python/cpython/commit/8766cb74e186d3820db0a855.patch";
+                  sha256 = "IzAp3M6hpSNcbVRttzvXNDyAVK7vLesKZDEDkdYbuww=";
+                })
+                (pkgs.fetchpatch {
+                  url = "https://github.com/python/cpython/commit/f0be4bbb9b3cee876249c23f.patch";
+                  sha256 = "FUF7ZkkatS4ON4++pR9XJQFQLW1kKSVzSs8NAS19bDY=";
+                })];
+              });
+            }
             { condition = version: versionInBetween version "3.4" "3.0";
               override = pkg: (pkg.override {
                 # no existing patch available
@@ -214,6 +227,13 @@
 
             mkdir $out
             ${python}/bin/python -c 'import ssl; print(ssl.OPENSSL_VERSION)' | tee $out/openssl-version
+          '';
+        } // lib.optionalAttrs (versionInBetween version "3.12" "3.6") {
+          ${version + "-ensurepip"} = pkgs.runCommand "${version}-test-ensurepip" { } ''
+            set -x
+
+            mkdir $out
+            ${python}/bin/python -m ensurepip --help | tee $out/ensurepip-help
           '';
         }) self.packages.${system});
   };


### PR DESCRIPTION
Fixes #23 

Just needed to apply patches from https://bugs.python.org/issue45700 to 3.6

Tested:
```shell
$ nix shell ~/projects/nixpkgs-python#'"3.6.14"' --extra-experimental-features nix-command --extra-experimental-features flakes --no-eval-cache
warning: ignoring untrusted substituter 'https://nixpkgs-python.cachix.org', you are not a trusted user.
Run `man nix.conf` for more information on the `substituters` configuration option.
$ python3.6 -m venv --clear .venv
$ . ./.venv/bin/activate
$ pip3 install -U pip
Collecting pip
  Using cached https://files.pythonhosted.org/packages/a4/6d/6463d49a933f547439d6b5b98b46af8742cc03ae83543e4d7688c2420f8b/pip-21.3.1-py3-none-any.whl
Installing collected packages: pip
  Found existing installation: pip 18.1
    Uninstalling pip-18.1:
      Successfully uninstalled pip-18.1
Successfully installed pip-21.3.1
```

I also added an `ensurepip` smoke test.

CI seems to fail but for unrelated changes?
```
<snip>
2024-09-30T15:05:44.8522165Z v2.7.18.6_CVE.tar.gz> curl: (56) The requested URL returned error: 404
2024-09-30T15:05:44.8524611Z v2.7.18.6_CVE.tar.gz> error: cannot download v2.7.18.6_CVE.tar.gz from any mirror
2024-09-30T15:05:44.8683718Z error: builder for '/nix/store/ljxz1qjhxrml9shv3aknfjjlycx8nzmp-v2.7.18.6_CVE.tar.gz.drv' failed with exit code 1;
2024-09-30T15:05:44.8693603Z        > curl: (56) The requested URL returned error: 404
2024-09-30T15:05:44.8694508Z        > error: cannot download v2.7.18.6_CVE.tar.gz from any mirror
2024-09-30T15:05:44.8733242Z error: 1 dependencies of derivation '/nix/store/2c852bmj7hrrfy7r1nzlndmnfgqvc87l-python-2.7.18.6._CVE.drv' failed to build
<snip>
2024-09-30T15:11:16.4611034Z error: 1 dependencies of derivation '/nix/store/0pa6gzc0nry6n5mrn5aqapa9lhmbq6s1-2.7.18.6_CVE-test-ssl.drv' failed to build
2024-09-30T15:11:16.4759157Z error: build of '/nix/store/0pa6gzc0nry6n5mrn5aqapa9lhmbq6s1-2.7.18.6_CVE-test-ssl.drv', '/nix/store/2c852bmj7hrrfy7r1nzlndmnfgqvc87l-python-2.7.18.6._CVE.drv' failed
```