### PR TITLE
Remove dead version

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -591,14 +591,6 @@
         "2.7.18.9": {
             "hash": "Tl94mHYHLTDKhYxwaPVvPqhNC+V2QzV+F67jKSMA39U=",
             "url": "https://github.com/ActiveState/cpython/archive/refs/tags/v2.7.18.9.tar.gz"
-        },
-        "2.7.18.6_CVE_RC3": {
-            "hash": "SrG3wgRfkbfasPkCtwmiklYfE438g/AxHUeAhVea9Bw=",
-            "url": "https://github.com/ActiveState/cpython/archive/refs/tags/v2.7.18.6_CVE_RC3.tar.gz"
-        },
-        "2.7.18.6_CVE": {
-            "hash": "sV47Vxry4BHor9PLhN5bFKWFTKv4LBemrWgzVupiZR0=",
-            "url": "https://github.com/ActiveState/cpython/archive/refs/tags/v2.7.18.6_CVE.tar.gz"
         }
     },
     "latest": {


### PR DESCRIPTION
Version 2.7.18.6_CVE does not exist in the ActiveState repos anymore. This removes it so the update.py script can continue on and the checks pass, again.
