### PR TITLE
Avoid duplicating nixpkgs in the nix store

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -181,7 +181,7 @@
             };
           };
 
-          pythonFun = import "${pkgs.path}/pkgs/development/interpreters/python/cpython/${infix}default.nix";
+          pythonFun = import "${toString pkgs.path}/pkgs/development/interpreters/python/cpython/${infix}default.nix";
           python = (self.lib.applyOverrides overrides (callPackage pythonFun ({
             inherit sourceVersion;
             hash = null;


### PR DESCRIPTION
I noticed that this line was making my nix evaluations significantly slower. It turns out that simply evaluating  `"${pkgs.path}"` causes nixpkgs to be copied into the nix store an extra time.

e.g. notice the two different paths here:

```
nix-repl> pkgs.path
/nix/store/p69bcs7ma6ijj8v9xsrg3nq3nn8ryn95-source

nix-repl> "${pkgs.path}"
"/nix/store/aj917y3jd6srg7jfmhgwglbfx36l5h9b-p69bcs7ma6ijj8v9xsrg3nq3nn8ryn95-source"
```

~I'm not sure if this is a problem when running under flakes, but I am consuming this in a repo that is too big to enable flakes with.~ EDIT: I believe that flakes do suffer the extra copy, but its much less noticeable due to flake evaluation caching.