### PR TITLE
deps: switch to 24.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -18,16 +18,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719253556,
-        "narHash": "sha256-A/76RFUVxZ/7Y8+OMVL1Lc8LRhBxZ8ZE2bpMnvZ1VpY=",
+        "lastModified": 1743367904,
+        "narHash": "sha256-sOos1jZGKmT6xxPvxGQyPTApOunXvScV4lNjBCXd/CI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fc07dc3bdf2956ddd64f24612ea7fc894933eb2e",
+        "rev": "7ffe0edc685f14b8c635e3d6591b0bbb97365e6c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -173,6 +173,12 @@
                 ''+ old.postInstall;
               });
             }
+            # The patch for CVE-2025-0938 is available for 3.9+
+            # https://www.cve.org/CVERecord?id=CVE-2025-0938
+            # https://github.com/python/cpython/pull/129418
+            { condition = version: versionInBetween version "3.9" "2";
+              override = filterOutPatch "CVE-2025-0938.patch";
+            }
           ];
           callPackage = pkgs.newScope {
             inherit python;

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "All Python versions packages in Nix.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     flake-compat.url = "github:edolstra/flake-compat";
     flake-compat.flake = false;
   };

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
   };
 
   nixConfig = {
-    substituters = "https://cache.nixos.org https://nixpkgs-python.cachix.org";
+    extra-substituters = "https://nixpkgs-python.cachix.org";
     extra-trusted-public-keys = "nixpkgs-python.cachix.org-1:hxjI7pFxTyuTHn2NkvWCrAUcNZLNS3ZAvfYNuYifcEU=";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -176,7 +176,7 @@
             # The patch for CVE-2025-0938 is available for 3.9+
             # https://www.cve.org/CVERecord?id=CVE-2025-0938
             # https://github.com/python/cpython/pull/129418
-            { condition = version: versionInBetween version "3.9" "2";
+            { condition = version: versionInBetween version "3.12" "2";
               override = filterOutPatch "CVE-2025-0938.patch";
             }
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -161,7 +161,7 @@
             { condition = version: versionInBetween version "3.7" "3.0";
               override = pkg: pkg.overrideAttrs  (old: {
                 prePatch = ''
-                  substituteInPlace Lib/subprocess.py --replace '"/bin/sh"' "'/bin/sh'"
+                  substituteInPlace Lib/subprocess.py --replace-fail '"/bin/sh"' "'/bin/sh'"
                 '' + old.prePatch;
               });
             }


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33?narHash=sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U%3D' (2023-10-04)
  → 'github:edolstra/flake-compat/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec?narHash=sha256-NeCCThCEP3eCl2l/%2B27kNNK7QrwZB1IJCrXfrbv5oqU%3D' (2024-12-04)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/fc07dc3bdf2956ddd64f24612ea7fc894933eb2e?narHash=sha256-A/76RFUVxZ/7Y8%2BOMVL1Lc8LRhBxZ8ZE2bpMnvZ1VpY%3D' (2024-06-24)
  → 'github:NixOS/nixpkgs/7ffe0edc685f14b8c635e3d6591b0bbb97365e6c?narHash=sha256-sOos1jZGKmT6xxPvxGQyPTApOunXvScV4lNjBCXd/CI%3D' (2025-03-30)