### PR TITLE
Avoid duplicating nixpkgs in the store harder (follow-up to #67)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -308,7 +308,7 @@
                   inherit sourceVersion;
                   hash = "sha256-${hash}";
                   self = packages.${version};
-                  passthruFun = callPackage "${pkgs.path}/pkgs/development/interpreters/python/passthrufun.nix" { };
+                  passthruFun = callPackage "${toString pkgs.path}/pkgs/development/interpreters/python/passthrufun.nix" { };
                 }
                 // lib.optionalAttrs (sourceVersion.major == "3") {
                   noldconfigPatch = ./patches + "/${sourceVersion.major}.${sourceVersion.minor}-no-ldconfig.patch";


### PR DESCRIPTION
This is similar to and a follow-up to #67 but does the same for `passthruFun`

More or less because `pkgs.path` is of path type (rather than string type), doing `${pkgs.path}` causes an extra copying to the store [because of the way string interpolation works on paths](https://nix.dev/manual/nix/2.34/language/string-interpolation.html#interpolated-expression) (when it is already a store path pointing to the flake source and should not need extra copying). This should be avoided by using the path directly as a string (alternatively this could be done via `pkgs.path + "/..."` as well, but this matches line 299 and they are functionally equivalent in this case)