### PR TITLE
Skip ActiveState pre-release versions; remove broken 2.7.18.14 hash

### DIFF
--- a/scripts/update.py
+++ b/scripts/update.py
@@ -92,7 +92,7 @@ def get_activestate_releases(response, versions, session):
         cycle = ".".join(version.split(".")[:2])
         release = versions["releases"].get(version, {})
 
-        if cycle != "2.7":
+        if cycle != "2.7" or entry["prerelease"]:
             continue
 
         versions["latest"][cycle] = max(

--- a/versions.json
+++ b/versions.json
@@ -795,10 +795,6 @@
         "3.14.5": {
             "hash": "nCK/6ZOabFQY/HSyiaXxzEGFmugqxrFjAWtYRL0Khrw=",
             "url": "https://www.python.org/ftp/python/3.14.5/Python-3.14.5.tgz"
-        },
-        "2.7.18.14": {
-            "hash": "2IwhXClKwYZsduN1Cshrm2SNLrUa26FBC41tQqIVuqM=",
-            "url": "https://github.com/ActiveState/cpython/archive/refs/tags/2.7.18.14.tar.gz"
         }
     },
     "latest": {
@@ -812,7 +808,7 @@
         "3.5": "3.5.10",
         "3.4": "3.4.10",
         "3.3": "3.3.7",
-        "2.7": "2.7.18.14",
+        "2.7": "2.7.18.13",
         "3.13": "3.13.13",
         "3.14": "3.14.5"
     }


### PR DESCRIPTION
ActiveState pre-releases do not have a finalized hash; indeed, the hash of 2.7.18.14 has already changed since it was added to versions.json.